### PR TITLE
MODSOURCE-120: extend sourceRecods.json with externalIdsHolder field

### DIFF
--- a/examples/mod-source-record-storage/sourceRecord.sample
+++ b/examples/mod-source-record-storage/sourceRecord.sample
@@ -444,6 +444,9 @@
   },
   "deleted" : false,
   "order": 0,
+  "externalIdsHolder": {
+    "instanceId": "86295b3c-5cb9-47cd-95a9-35b6a3498780"
+  },
   "additionalInfo": {
     "suppressDiscovery": false
   }

--- a/examples/mod-source-record-storage/sourceRecordCollection.sample
+++ b/examples/mod-source-record-storage/sourceRecordCollection.sample
@@ -446,6 +446,9 @@
       },
       "deleted": false,
       "order": 0,
+      "externalIdsHolder": {
+        "instanceId": "86295b3c-5cb9-47cd-95a9-35b6a3498780"
+      },
       "additionalInfo": {
         "suppressDiscovery": false
       }

--- a/schemas/dto/sourceRecord.json
+++ b/schemas/dto/sourceRecord.json
@@ -37,6 +37,11 @@
       "type": "integer",
       "minimum": 0
     },
+    "externalIdsHolder": {
+      "description": "Container for identifiers of external entities",
+      "type": "object",
+      "$ref": "../common/externalIdsHolder.json"
+    },
     "additionalInfo": {
       "description": "Auxiliary data which is not related to MARC type record",
       "type": "object",


### PR DESCRIPTION
### PURPOSE 
Extend sourceRecord dto/json with new externalIdsaHolder field due to functional purposes in other modules. 
### TICKET
https://issues.folio.org/browse/MODSOURCE-120