### PR TITLE
MODSOURMAN-381 - Expanded journalRecord schema with NON_MATCH action

### DIFF
--- a/schemas/dto/jobLogEntryDto.json
+++ b/schemas/dto/jobLogEntryDto.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Job summary log entry DTO schema",
+  "javaType": "org.folio.rest.jaxrs.model.JobLogEntryDto",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/schemas/mod-source-record-manager/journalRecord.json
+++ b/schemas/mod-source-record-manager/journalRecord.json
@@ -53,7 +53,7 @@
         "UPDATE",
         "DELETE",
         "MODIFY",
-        "ERROR"
+        "NON_MATCH"
       ]
     },
     "actionStatus": {


### PR DESCRIPTION
**Purpose:** for the data import log needs, it is necessary to show that an import job was finished due to an entity has not been matched by criteria in a match profile