### PR TITLE
MODDATAIMP-350 FOLIO-2926 Use buildNode jenkins-agent-java11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
   agent {
     node {
-      label 'jenkins-slave-all'
+      label 'jenkins-agent-java11'
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # data-import-raml-storage
 
-Copyright (C) 2018 The Open Library Foundation
+Copyright (C) 2018-2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0.
 See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The old buildNode is deprecated.
In Jenkinsfile, use the new buildNode label "jenkins-agent-java11" instead of the old label "jenkins-slave-all".
See [FOLIO-2926](https://issues.folio.org/browse/FOLIO-2926)