### PR TITLE
remove leader record status u

### DIFF
--- a/schemas/dto/record.json
+++ b/schemas/dto/record.json
@@ -74,7 +74,7 @@
     "leaderRecordStatus": {
       "description": "Single character representing MARC leader 05",
       "type": "string",
-      "pattern": "^[a|c|d|n|p|o|s|u|x]{1}$"
+      "pattern": "^[a|c|d|n|p|o|s|x]{1}$"
     },
     "metadata": {
       "description": "Metadata provided by the server",


### PR DESCRIPTION
After consulting with a librarian, it turns out we unintentionally use leader record status u and it is actually not valid.