### PR TITLE
MODSOURMAN-410: Change the sourceRecordOrder type to support invoice line numbers.

### DIFF
--- a/schemas/dto/jobLogEntryDto.json
+++ b/schemas/dto/jobLogEntryDto.json
@@ -15,8 +15,7 @@
     },
     "sourceRecordOrder": {
       "description": "Order of a record in imported file",
-      "type": "integer",
-      "minimum": 0
+      "type": "string"
     },
     "sourceRecordTitle": {
       "description": "Title from record",


### PR DESCRIPTION
## Purpose
Expand data import log functionality for EDIFACT records.

## Approach
The sourceRecordOrder type was changes from Integer to String to transfer invoice line numbers to UI.

## Learning
[MODSOURMAN-410](https://issues.folio.org/browse/MODSOURMAN-410)
