### PR TITLE
MODSOURMAN-420 - Expand endpoint for retrieving recordProcessingLogDto to support Invoice JSON screen

### DIFF
--- a/schemas/dto/jobLogEntryDto.json
+++ b/schemas/dto/jobLogEntryDto.json
@@ -48,6 +48,10 @@
     "error": {
       "description": "Error message",
       "type": "string"
+    },
+    "invoiceLineJournalRecordId": {
+      "description": "UUID of journalRecord which keeps data of particular invoice line processing",
+      "$ref": "../common/uuid.json"
     }
   },
   "required": [

--- a/schemas/dto/recordProcessingLogDto.json
+++ b/schemas/dto/recordProcessingLogDto.json
@@ -48,6 +48,29 @@
     "relatedInvoiceInfo": {
       "description": "Information about invoice associated with source record",
       "$ref": "processedEntityInfo.json"
+    },
+    "relatedInvoiceLineInfo": {
+      "description": "Information about invoice line associated with source record",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "actionStatus": {
+          "description": "Status of action performed with invoice line",
+          "$ref": "./actionStatus.json"
+        },
+        "id": {
+          "description": "Invoice line identifier, UUID",
+          "$ref": "../common/uuid.json"
+        },
+        "fullInvoiceLineNumber": {
+          "description": "Consists of vendor invoice number and invoice line sequence number",
+          "type": "string"
+        },
+        "error": {
+          "description": "Error message",
+          "type": "string"
+        }
+      }
     }
   },
   "required": [


### PR DESCRIPTION
## Purpose
to provide data of the particular invoice line for Invoice JSON screen

## Approach
* expanded `recordProcessingLogDto` schema to provide invoice line data
* expanded `jobLogEntryDto` schema with "invoiceLineJournalRecordId" property to get data for the certain invoice line

## Learning
[MODSOURMAN-420](https://issues.folio.org/browse/MODSOURMAN-420), [UIDATIMP-817](https://issues.folio.org/browse/UIDATIMP-817)
