### PR TITLE
FOLIO-2917 Use api-schema-lint facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,9 @@ pipeline {
       }
     }
 
-    stage('Lint raml schema') {
+    stage('API schema lint') {
       steps {
-        runLintRamlSchema()
+        runApiSchemaLint('.', '')
       }
     }
 


### PR DESCRIPTION
Ensure that API JSON Schema has property descriptions.
Replaces old RAML facility.
See [FOLIO-2917](https://issues.folio.org/browse/FOLIO-2917).
