### PR TITLE
MODSOURMAN-550. Reduce BE response payload for DI Landing Page to increase performance

### DIFF
--- a/schemas/dto/jobExecutionDto.json
+++ b/schemas/dto/jobExecutionDto.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Job Execution Schema",
+  "type": "object",
+  "javaType": "org.folio.rest.jaxrs.model.JobExecutionDto",
+  "properties": {
+    "id": {
+      "description": "Unique identifier",
+      "$ref": "../common/uuid.json"
+    },
+    "hrId": {
+      "description": "Human readable id",
+      "type": "integer"
+    },
+    "parentJobId": {
+      "description": "Id of the parent JobExecution entity",
+      "$ref": "../common/uuid.json"
+    },
+    "subordinationType": {
+      "description": "Type of subordination to another JobExecution entities",
+      "type": "string",
+      "enum": [
+        "CHILD",
+        "PARENT_SINGLE",
+        "PARENT_MULTIPLE"
+      ]
+    },
+    "jobProfileInfo": {
+      "description": "Related JobProfile information",
+      "type": "object",
+      "$ref": "../common/profileInfo.json"
+    },
+    "sourcePath": {
+      "description": "Path to the file",
+      "type": "string"
+    },
+    "fileName": {
+      "description": "File name",
+      "type": "string"
+    },
+    "runBy": {
+      "description": "First and last name of the user that triggered the job execution",
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "description": "First name",
+          "type": "string"
+        },
+        "lastName": {
+          "description": "Last name",
+          "type": "string"
+        }
+      }
+    },
+    "progress": {
+      "description": "Execution progress of the job",
+      "type": "object",
+      "$ref": "../mod-source-record-manager/progress.json"
+    },
+    "startedDate": {
+      "description": "Date and time when the job execution started",
+      "type": "string",
+      "format": "date-time"
+    },
+    "completedDate": {
+      "description": "Date and time when the job execution completed",
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "description": "Current status of the job execution",
+      "type": "string",
+      "$ref": "../common/status.json"
+    },
+    "uiStatus": {
+      "description": "Status that is rendered on UI",
+      "type": "string",
+      "$ref": "../mod-source-record-manager/uiStatus.json"
+    },
+    "errorStatus": {
+      "description": "Status that describe error state of job execution",
+      "type": "string",
+      "$ref": "../mod-source-record-manager/errorStatus.json"
+    },
+    "userId": {
+      "description": "ID of the user who created the JobExecution",
+      "$ref": "../common/uuid.json"
+    }
+  },
+  "required": [
+    "id",
+    "parentJobId",
+    "subordinationType",
+    "status",
+    "uiStatus",
+    "userId"
+  ],
+  "excludedFromEqualsAndHashCode": [
+    "hrId",
+    "progress",
+    "runBy"
+  ]
+}

--- a/schemas/dto/jobExecutionDto.json
+++ b/schemas/dto/jobExecutionDto.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Job Execution Schema",
+  "description": "Job Execution Dto Schema",
   "type": "object",
   "javaType": "org.folio.rest.jaxrs.model.JobExecutionDto",
   "properties": {

--- a/schemas/dto/jobExecutionDtoCollection.json
+++ b/schemas/dto/jobExecutionDtoCollection.json
@@ -1,16 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Collection of execution jobs",
+  "description": "Collection of execution job dtos",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "jobExecutions": {
-      "description": "List of execution jobs",
+      "description": "List of execution job dtos",
       "type": "array",
       "id": "jobExecutionList",
       "items": {
         "type": "object",
-        "$ref": "jobExecution.json"
+        "$ref": "jobExecutionDto.json"
       }
     },
     "totalRecords": {


### PR DESCRIPTION
Start using lightweight dto objects for JobExecutionCollection (without jobProfileSnapshotWrapper) to avoid high Network traffic and speed-up performance

Current situation with Network traffic in Juniper Bugfest env presented here:
![image](https://user-images.githubusercontent.com/25097693/130767078-0e04c4cb-9548-4857-a764-bc8065747684.png)
