### PR TITLE
MODSOURCE-355 Added "MATCH" action status to JournalRecord

### DIFF
--- a/schemas/mod-source-record-manager/journalRecord.json
+++ b/schemas/mod-source-record-manager/journalRecord.json
@@ -54,6 +54,7 @@
         "UPDATE",
         "DELETE",
         "MODIFY",
+        "MATCH",
         "NON_MATCH"
       ]
     },


### PR DESCRIPTION
## Purpose
It is necessary to ensure that while data import record save and successful match in mod-source-record-storage, used eventChain type available in mod-source-record-manager’s JournalParams enum
## Approach

- Applied eventChain type in mod-source-record-storage available in JournalParams enum which participates in handling of data import record in mod-source-record-manager.

## Learning
https://issues.folio.org/browse/MODSOURCE-355