### PR TITLE
MODDICORE-264 Support correlationId header

### DIFF
--- a/schemas/common/dataImportEventPayload.json
+++ b/schemas/common/dataImportEventPayload.json
@@ -45,6 +45,10 @@
       "description": "Okapi URL",
       "type": "string"
     },
+    "correlationId": {
+      "description": "Id intended to track events related to the same action",
+      "type": "string"
+    },
     "context": {
       "description": "HashMap with objects. Key - entity type, Value - object in json representation",
       "javaType": "java.util.HashMap<String, String>"


### PR DESCRIPTION
## Purpose
`correlationId` header should be passed to all data-import events. It's needed to track events that are related to the same action.

## Approach
- Update DataImportEventPayload schema to have `correlationId` field

## Learning
[MODDICORE-264](https://issues.folio.org/browse/MODDICORE-264)