### PR TITLE
MODSOURMAN-796. Change logic to initialize job execution progress after reading file instead of processing the first chunk

### DIFF
--- a/examples/mod-data-import/dataImportInitConfig.sample
+++ b/examples/mod-data-import/dataImportInitConfig.sample
@@ -1,0 +1,4 @@
+{
+  "jobExecutionId": "43723fe8-ce67-4207-a9ae-297f18ee9888",
+  "totalRecords": 50
+}

--- a/schemas/common/dataImportEventTypes.json
+++ b/schemas/common/dataImportEventTypes.json
@@ -4,6 +4,7 @@
   "type": "string",
   "additionalProperties": false,
   "enum": [
+    "DI_INITIALIZATION_STARTED",
     "DI_EDIFACT_RECORD_CREATED",
     "DI_RAW_RECORDS_CHUNK_READ",
     "DI_MARC_FOR_UPDATE_RECEIVED",

--- a/schemas/common/dataImportInitConfig.json
+++ b/schemas/common/dataImportInitConfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Payload for data-import initialization",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "jobExecutionId": {
+      "description": "UUID",
+      "$ref": "../../raml-util/schemas/uuid.schema"
+    },
+    "totalRecords": {
+      "description": "Total number of records",
+      "type": "integer"
+    }
+  },
+  "excludedFromEqualsAndHashCode": [
+    "totalRecords"
+  ],
+  "required": [
+    "jobExecutionId",
+    "totalRecords"
+  ]
+}


### PR DESCRIPTION
New event 'DI_INITIALIZATION_STARTED' has been introduced. It will push dataImportInitConfig from mod-data-import.
Mod-source-record-manager will consume this event and initialize job execution progress to be visible in Running section on UI