### PR TITLE
[MODDATAIMP-894] Remove unused DI queue property size

### DIFF
--- a/schemas/mod-data-import/dataImportQueueItem.json
+++ b/schemas/mod-data-import/dataImportQueueItem.json
@@ -20,12 +20,8 @@
       "description": "The tenant which this chunk and job belong to",
       "type": "string"
     },
-    "size": {
-      "description": "Size of the file",
-      "type": "integer"
-    },
     "originalSize": {
-      "description": "size of the parent file if it exists",
+      "description": "size of the original/parent file, in records",
       "type": "integer"
     },
     "filePath": {


### PR DESCRIPTION
# [Jira MODDATAIMP-894](https://issues.folio.org/browse/MODDATAIMP-894)

This removes the unused `size` column (for chunks; the job size column `originalSize` is preserved).