### PR TITLE
[MODDATAIMP-842] Move S3 storage schemas into proper location

### DIFF
--- a/schemas/mod-data-import/fileDownloadInfo.json
+++ b/schemas/mod-data-import/fileDownloadInfo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "file download info, returned when requesting a presigned S3 url",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "url": {
+      "description": "presigned url to be used for direct s3 download",
+      "type": "string"
+    }
+  },
+  "required": ["url"]
+}

--- a/schemas/mod-data-import/fileUploadInfo.json
+++ b/schemas/mod-data-import/fileUploadInfo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "file upload info json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "url": {
+      "description": "presigned url to be used for direct s3 upload",
+      "type": "string"
+    },
+    "key": {
+      "description": "Key for file upload on S3 storage",
+      "type": "string"
+    },
+    "uploadId": {
+      "description": "Multipart upload ID",
+      "type": "string"
+    }
+  },
+  "required": ["url", "key", "uploadId"]
+}


### PR DESCRIPTION
Moves `fileUploadInfo` and the new `fileDownloadInfo` from `mod-data-import` itself into this common location