### PR TITLE
[MODDATAIMP-836] Add job profile ID to queue item

### DIFF
--- a/schemas/mod-data-import/dataImportQueueItem.json
+++ b/schemas/mod-data-import/dataImportQueueItem.json
@@ -16,6 +16,10 @@
       "description": "upload Definition Id",
       "$ref": "../../raml-util/schemas/uuid.schema"
     },
+    "jobProfileId": {
+      "description": "the ID of the job profile being used to process this queue item",
+      "$ref": "../../raml-util/schemas/uuid.schema"
+    },
     "tenant": {
       "description": "The tenant which this chunk and job belong to",
       "type": "string"


### PR DESCRIPTION
Adds a column for the job profile ID to the queue item schema.  This is needed so that the job profile can be used when the job is later executed.

Basing this against a version of @TarasSpashchenko's branch since this change is based off some of his changes and attempting to compare it to the main DITF one results in a mess.