### PR TITLE
MODDICONV-307: Populate "value" with empty string if this field is absent in match profile incoming indicators

### DIFF
--- a/schemas/mod-data-import-converter-storage/match-profile-detail/fieldDefinition.json
+++ b/schemas/mod-data-import-converter-storage/match-profile-detail/fieldDefinition.json
@@ -10,7 +10,8 @@
     },
     "value": {
       "description": "Field or subfield name in record",
-      "type": "string"
+      "type": "string",
+      "default": ""
     }
   },
   "required": [


### PR DESCRIPTION
## Purpose 
Populate "value" with empty string if this field is absent in match profile incoming records indicators
## Approach
Keep in Poppy for now

Populate "value" with an empty string if this field is absent in match profile incoming records indicators

As far as, if we would write a value to the indicator field at the matching profile and after that delete this value we will send the entity without the "value" field, we need to handle the absent value field on BE, to prevent producing of NPE.

Possibly in the field definition schema add default value for indicators to be empty string, not null. Update references to raml-storage.

Check if this problem is relevant for Action and Job profiles. For Mapping it should have been fixed already.

### P.S. 
After the investigation of the issue on the action and job profiles, there weren't any similar issues like this. But if you found any related issue, please comment it.