### PR TITLE
MODSOURMAN-1044 - Add "tenantId" field to the recordProcessingLogDto schema

### DIFF
--- a/examples/mod-source-record-manager/journalRecord.sample
+++ b/examples/mod-source-record-manager/journalRecord.sample
@@ -9,6 +9,7 @@
   "entityHrId": "",
   "actionType": "CREATE",
   "actionStatus": "COMPLETED",
-  "title": "Source record title"
-  "actionDate": "2019-12-03T15:26:57.921+0000"
+  "title": "Source record title",
+  "actionDate": "2019-12-03T15:26:57.921+0000",
+  "tenantId": "mobius"
 }

--- a/examples/mod-source-record-manager/recordProcessingLogDto.sample
+++ b/examples/mod-source-record-manager/recordProcessingLogDto.sample
@@ -4,6 +4,7 @@
   "sourceRecordOrder": 0,
   "sourceRecordTitle": "Burn it down",
   "sourceRecordActionStatus": "CREATED",
+  "sourceRecordTenantId": "mobius",
   "relatedInstanceInfo": {
     "actionStatus": "UPDATED",
     "idList": [

--- a/schemas/dto/processedEntityInfo.json
+++ b/schemas/dto/processedEntityInfo.json
@@ -26,6 +26,10 @@
     "error": {
       "description": "Error message",
       "type": "string"
+    },
+    "tenantId": {
+      "description": "Id of tenant in which action was performed over entity",
+      "type": "string"
     }
   }
 }

--- a/schemas/dto/recordProcessingLogDto.json
+++ b/schemas/dto/recordProcessingLogDto.json
@@ -29,6 +29,10 @@
       "description": "Error message",
       "type": "string"
     },
+    "sourceRecordTenantId": {
+      "description": "Error message",
+      "type": "string"
+    },
     "relatedInstanceInfo": {
       "description": "Information about instance associated with source record",
       "$ref": "processedEntityInfo.json"

--- a/schemas/dto/recordProcessingLogDto.json
+++ b/schemas/dto/recordProcessingLogDto.json
@@ -30,7 +30,7 @@
       "type": "string"
     },
     "sourceRecordTenantId": {
-      "description": "Error message",
+      "description": "Id of tenant in which action was performed over record",
       "type": "string"
     },
     "relatedInstanceInfo": {

--- a/schemas/mod-source-record-manager/journalRecord.json
+++ b/schemas/mod-source-record-manager/journalRecord.json
@@ -98,7 +98,7 @@
       "format": "date-time"
     },
     "tenantId": {
-      "description": "Id of tenant in which action was performed over entity. Mostly used to save the Id of the central tenant in which the record/entity was updated by data import on member tenant",
+      "description": "Id of tenant in which action was performed over entity. Mostly used to save the Id of the central tenant in which the record/entity was updated by data import initiated on member tenant",
       "type": "string"
     }
   },

--- a/schemas/mod-source-record-manager/journalRecord.json
+++ b/schemas/mod-source-record-manager/journalRecord.json
@@ -77,7 +77,7 @@
       ]
     },
     "actionStatus": {
-      "description": "Type of action",
+      "description": "Status of action",
       "type": "string",
       "enum": [
         "COMPLETED",
@@ -96,6 +96,10 @@
       "description": "Date and time when action was performed during record processing",
       "type": "string",
       "format": "date-time"
+    },
+    "tenantId": {
+      "description": "Id of tenant in which action was performed over entity. Mostly used to save the Id of the central tenant in which the record/entity was updated by data import on member tenant",
+      "type": "string"
     }
   },
   "required": [


### PR DESCRIPTION
## Purpose
to provide marc record and instance on the logs page when marc-to-marc matching and marc-bib update has been performed on the central tenant by data import initiated on member tenant

## Approach
* add "sourceRecordTenantId" field to recordProcessingLogDto schema and "tenantId" into the processedEntityInfo schema, which describe the response returned for the logs page with jsons. Newly added fields are needed to provide central tenantId and indicate that marc record and instance should be requested by ui from the central tenant to show them on the page


## Learning
[MODSOURMAN-1044](https://issues.folio.org/browse/MODSOURMAN-1044)