### PR TITLE
Add okapi token and permissions to DI queue item schema

### DIFF
--- a/schemas/mod-data-import/dataImportQueueItem.json
+++ b/schemas/mod-data-import/dataImportQueueItem.json
@@ -53,6 +53,10 @@
     "okapiToken": {
       "description": "The original module-level permission token granted by Okapi for the originating user",
       "type": "string"
+    },
+    "okapiPermissions": {
+      "description": "The original module-level x-okapi-permission header, as provided by Okapi",
+      "type": "string"
     }
   },
   "required": [
@@ -67,6 +71,7 @@
     "processing",
     "okapiUrl",
     "dataType",
-    "okapiToken"
+    "okapiToken",
+    "okapiPermissions"
   ]
 }

--- a/schemas/mod-data-import/dataImportQueueItem.json
+++ b/schemas/mod-data-import/dataImportQueueItem.json
@@ -49,6 +49,10 @@
     "dataType": {
       "description": "The dataType from the original job profile, e.g. MARC",
       "type": "string"
+    },
+    "okapiToken": {
+      "description": "The original module-level permission token granted by Okapi for the originating user",
+      "$ref": "../../raml-util/schemas/uuid.schema"
     }
   },
   "required": [
@@ -62,6 +66,7 @@
     "partNumber",
     "processing",
     "okapiUrl",
-    "dataType"
+    "dataType",
+    "okapiToken"
   ]
 }

--- a/schemas/mod-data-import/dataImportQueueItem.json
+++ b/schemas/mod-data-import/dataImportQueueItem.json
@@ -52,7 +52,7 @@
     },
     "okapiToken": {
       "description": "The original module-level permission token granted by Okapi for the originating user",
-      "$ref": "../../raml-util/schemas/uuid.schema"
+      "type": "string"
     }
   },
   "required": [


### PR DESCRIPTION
As part of MODDATAIMP-953, we need to store and use the user's okapi token and permissions when processing an import