### PR TITLE
MODSOURMAN-1353: make `relatedRecordVersion` not required

### DIFF
--- a/schemas/dto/parsedRecordDto.json
+++ b/schemas/dto/parsedRecordDto.json
@@ -52,7 +52,6 @@
   "required": [
     "id",
     "recordType",
-    "relatedRecordVersion",
     "parsedRecord"
   ]
 }


### PR DESCRIPTION
**Purpose**
`relatedRecordVersion` will be removed from the schema. For now, making it not required, not to break modules that uses it.